### PR TITLE
enable constructor overrides via QueueManager methods

### DIFF
--- a/src/QueueManager.js
+++ b/src/QueueManager.js
@@ -62,12 +62,22 @@ class QueueManager {
 
   /**
    * @param {String} rpcName
+   * @param {RPCClient|function() : RPCClient} OverrideClass
    * @param {Object} [options]
    * @return RPCClient
    * */
-  getRPCClient (rpcName, options) {
+  getRPCClient (rpcName, OverrideClass = RPCClient, options = {}) {
     if (this.rpcClients.has(rpcName)) {
       return this.rpcClients.get(rpcName)
+    }
+
+    if (arguments.length === 2 && typeof OverrideClass !== 'function') {
+      options = OverrideClass
+      OverrideClass = RPCClient
+    }
+
+    if (OverrideClass !== RPCClient && !(OverrideClass.prototype instanceof RPCClient)) {
+      throw new Error('Override must be a subclass of RPCClient')
     }
 
     let settings = Object.assign({
@@ -75,7 +85,7 @@ class QueueManager {
       timeoutMs: this._config.rpcTimeoutMs
     }, options)
 
-    const rpcClient = new RPCClient(this.connection, this._logger, rpcName, settings)
+    const rpcClient = new OverrideClass(this.connection, this._logger, rpcName, settings)
 
     this.rpcClients.set(rpcName, rpcClient)
 
@@ -84,12 +94,22 @@ class QueueManager {
 
   /**
    * @param {String} rpcName
+   * @param {RPCServer|function() : RPCServer} OverrideClass
    * @param {Object} [options]
    * @return RPCServer
    */
-  getRPCServer (rpcName, options) {
+  getRPCServer (rpcName, OverrideClass = RPCServer, options = {}) {
     if (this.rpcServers.has(rpcName)) {
       return this.rpcServers.get(rpcName)
+    }
+
+    if (arguments.length === 2 && typeof OverrideClass !== 'function') {
+      options = OverrideClass
+      OverrideClass = RPCServer
+    }
+
+    if (OverrideClass !== RPCServer && !(OverrideClass.prototype instanceof RPCServer)) {
+      throw new Error('Override must be a subclass of RPCServer')
     }
 
     let settings = Object.assign({
@@ -97,7 +117,7 @@ class QueueManager {
       timeoutMs: this._config.rpcTimeoutMs
     }, options)
 
-    const rpcServer = new RPCServer(this.connection, this._logger, rpcName, settings)
+    const rpcServer = new OverrideClass(this.connection, this._logger, rpcName, settings)
 
     this.rpcServers.set(rpcName, rpcServer)
 
@@ -106,14 +126,19 @@ class QueueManager {
 
   /**
    * @param {String} exchangeName
+   * @param {Publisher|function() : Publisher} OverrideClass
    * @return Publisher
    */
-  getPublisher (exchangeName) {
+  getPublisher (exchangeName, OverrideClass = Publisher) {
     if (this.publishers.has(exchangeName)) {
       return this.publishers.get(exchangeName)
     }
 
-    const publisher = new Publisher(this.connection, this._logger, exchangeName)
+    if (OverrideClass !== Publisher && !(OverrideClass.prototype instanceof Publisher)) {
+      throw new Error('Override must be a subclass of Publisher')
+    }
+
+    const publisher = new OverrideClass(this.connection, this._logger, exchangeName)
 
     this.publishers.set(exchangeName, publisher)
 
@@ -122,12 +147,22 @@ class QueueManager {
 
   /**
    * @param {String} exchangeName
+   * @param {Subscriber|function() : Subscriber} OverrideClass
    * @param {Object} [options]
    * @return Subscriber
    */
-  getSubscriber (exchangeName, options) {
+  getSubscriber (exchangeName, OverrideClass = Subscriber, options = {}) {
     if (this.subscribers.has(exchangeName)) {
       return this.subscribers.get(exchangeName)
+    }
+
+    if (arguments.length === 2 && typeof OverrideClass !== 'function') {
+      options = OverrideClass
+      OverrideClass = Subscriber
+    }
+
+    if (OverrideClass !== Subscriber && !(OverrideClass.prototype instanceof Subscriber)) {
+      throw new Error('Override must be a subclass of Subscriber')
     }
 
     let settings = Object.assign({
@@ -136,7 +171,7 @@ class QueueManager {
       timeoutMs: this._config.rpcTimeoutMs
     }, options)
 
-    const subscriber = new Subscriber(this.connection, this._logger, exchangeName, settings)
+    const subscriber = new OverrideClass(this.connection, this._logger, exchangeName, settings)
 
     this.subscribers.set(exchangeName, subscriber)
 
@@ -145,14 +180,19 @@ class QueueManager {
 
   /**
    * @param {String} queueName
+   * @param {QueueClient|function() : QueueClient} OverrideClass
    * @return QueueClient
    */
-  getQueueClient (queueName) {
+  getQueueClient (queueName, OverrideClass = QueueClient) {
     if (this.queueClients.has(queueName)) {
       return this.queueClients.get(queueName)
     }
 
-    const queueClient = new QueueClient(this.connection, this._logger, queueName)
+    if (OverrideClass !== QueueClient && !(OverrideClass.prototype instanceof QueueClient)) {
+      throw new Error('Override must be a subclass of QueueClient')
+    }
+
+    const queueClient = new OverrideClass(this.connection, this._logger, queueName)
 
     this.queueClients.set(queueName, queueClient)
 
@@ -161,12 +201,22 @@ class QueueManager {
 
   /**
    * @param {String} queueName
+   * @param {QueueServer|function() : QueueServer} OverrideClass
    * @param {Object} [options]
    * @return QueueServer
    */
-  getQueueServer (queueName, options) {
+  getQueueServer (queueName, OverrideClass = QueueServer, options = {}) {
     if (this.queueServers.has(queueName)) {
       return this.queueServers.get(queueName)
+    }
+
+    if (arguments.length === 2 && typeof OverrideClass !== 'function') {
+      options = OverrideClass
+      OverrideClass = QueueServer
+    }
+
+    if (OverrideClass !== QueueServer && !(OverrideClass.prototype instanceof QueueServer)) {
+      throw new Error('Override must be a subclass of QueueServer')
     }
 
     let settings = Object.assign({
@@ -175,7 +225,7 @@ class QueueManager {
       timeoutMs: this._config.rpcTimeoutMs
     }, options)
 
-    const queueServer = new QueueServer(this.connection, this._logger, queueName, settings)
+    const queueServer = new OverrideClass(this.connection, this._logger, queueName, settings)
 
     this.queueServers.set(queueName, queueServer)
 

--- a/test/QueueManager.test.js
+++ b/test/QueueManager.test.js
@@ -1,3 +1,5 @@
+const chai = require('chai')
+const assert = chai.assert
 const QueueManager = require('../src/QueueManager')
 const Publisher = require('../src/Publisher')
 const Subscriber = require('../src/Subscriber')
@@ -64,5 +66,125 @@ describe('QueueManager', () => {
     }
 
     done()
+  })
+
+  // ==== RPCClient/RPCServer override
+
+  it('Provide a valid override class for RPCClient', () => {
+    const name = 'test-rpc-override-valid'
+    class Override extends RPCClient {}
+
+    const rpcClient = manager.getRPCClient(name, Override)
+
+    assert.instanceOf(rpcClient, RPCClient, 'not an instance of RPCClient')
+    assert.instanceOf(rpcClient, Override, 'not an instance of Override')
+  })
+
+  it('Provide an invalid override class for RPCClient', () => {
+    const name = 'test-rpc-override-invalid'
+    class Override {}
+
+    assert.throws(() => {
+      manager.getRPCClient(name, Override)
+    })
+  })
+
+  it('Provide a valid override class for RPCServer', () => {
+    const name = 'test-rpc-override-valid'
+    class Override extends RPCServer {}
+
+    const rpcServer = manager.getRPCServer(name, Override)
+
+    assert.instanceOf(rpcServer, RPCServer, 'not an instance of RPCServer')
+    assert.instanceOf(rpcServer, Override, 'not an instance of Override')
+  })
+
+  it('Provide an invalid override class for RPCServer', () => {
+    const name = 'test-rpc-override-invalid'
+    class Override {}
+
+    assert.throws(() => {
+      manager.getRPCServer(name, Override)
+    })
+  })
+
+  // ==== QueueClient/QueueServer override
+
+  it('Provide a valid override class for QueueClient', () => {
+    const name = 'test-queue-override-valid'
+    class Override extends QueueClient {}
+
+    const queueClient = manager.getQueueClient(name, Override)
+
+    assert.instanceOf(queueClient, QueueClient, 'not an instance of QueueClient')
+    assert.instanceOf(queueClient, Override, 'not an instance of Override')
+  })
+
+  it('Provide an invalid override class for QueueClient', () => {
+    const name = 'test-queue-override-invalid'
+    class Override {}
+
+    assert.throws(() => {
+      manager.getRPCClient(name, Override)
+    })
+  })
+
+  it('Provide a valid override class for QueueServer', () => {
+    const name = 'test-queue-override-valid'
+    class Override extends QueueServer {}
+
+    const queueServer = manager.getQueueServer(name, Override)
+
+    assert.instanceOf(queueServer, QueueServer, 'not an instance of QueueServer')
+    assert.instanceOf(queueServer, Override, 'not an instance of Override')
+  })
+
+  it('Provide an invalid override class for QueueServer', () => {
+    const rpc = 'test-queue-override-invalid'
+    class Override {}
+
+    assert.throws(() => {
+      manager.getQueueServer(rpc, Override)
+    })
+  })
+
+  // ==== Publisher/Subscriber override
+
+  it('Provide a valid override class for Publisher', () => {
+    const name = 'test-pubsub-override-valid'
+    class Override extends Publisher {}
+
+    const publisher = manager.getPublisher(name, Override)
+
+    assert.instanceOf(publisher, Publisher, 'not an instance of Publisher')
+    assert.instanceOf(publisher, Override, 'not an instance of Override')
+  })
+
+  it('Provide an invalid override class for Publisher', () => {
+    const name = 'test-pubsub-override-invalid'
+    class Override {}
+
+    assert.throws(() => {
+      manager.getPublisher(name, Override)
+    })
+  })
+
+  it('Provide a valid override class for Subscriber', () => {
+    const name = 'test-pubsub-override-valid'
+    class Override extends Subscriber {}
+
+    const subscriber = manager.getSubscriber(name, Override)
+
+    assert.instanceOf(subscriber, Subscriber, 'not an instance of Subscriber')
+    assert.instanceOf(subscriber, Override, 'not an instance of Override')
+  })
+
+  it('Provide an invalid override class for Subscriber', () => {
+    const rpc = 'test-pubsub-override-invalid'
+    class Override {}
+
+    assert.throws(() => {
+      manager.getSubscriber(rpc, Override)
+    })
   })
 })


### PR DESCRIPTION
This enables library users to extend handler classes like `QueueServer` and provide them in `QueueManager` getters like `getQueueServer` so they can implement custom logic without the need to wrap these classes.
