### PR TITLE
Updated RPC tests

### DIFF
--- a/src/RPCClient.js
+++ b/src/RPCClient.js
@@ -63,7 +63,7 @@ class RPCClient {
       if (this._correlationIdMap.has(correlationId)) {
         this._correlationIdMap.delete(correlationId)
 
-        reject(new Error('RCPCLIENT MESSAGE TIMEOUT ' + this.name))
+        reject(new Error('RPCCLIENT MESSAGE TIMEOUT ' + this.name))
       }
     }, timeoutMs || this._rpcTimeoutMs)
 
@@ -80,7 +80,7 @@ class RPCClient {
 
     return Promise.resolve().then(() => {
       if (this._correlationIdMap.size > this._rpcQueueMaxSize) {
-        throw new Error('RCPCLIENT QUEUE FULL ' + this.name)
+        throw new Error('RPCCLIENT QUEUE FULL ' + this.name)
       }
     }).then(() => {
       return this._connection.getChannel().then((ch) => {

--- a/test/RPC.test.js
+++ b/test/RPC.test.js
@@ -85,7 +85,7 @@ describe('RPCClient && RPCServer', () => {
     let objectMessage = {foo: 'bar', bar: 'foo'}
 
     rpcServer.consume((msg) => {
-      let now = new Date().getTime()
+      let now = Date.now()
       while (new Date().getTime() < now + timeoutMs + 100) { }
       return msg
     })
@@ -98,19 +98,18 @@ describe('RPCClient && RPCServer', () => {
   it(`RPCClient frees up memory after timeout`, (done) => {
     let objectMessage = {foo: 'bar', bar: 'foo'}
 
-    let first = true
-    shortRpcServer.consume((msg) => {
-      if (first) {
-        let now = new Date().getTime()
-        while (new Date().getTime() < now + timeoutMs + 100) { }
-        first = false
+    let waitForTimeout = true
+    shortRpcServer.consume(() => {
+      if (waitForTimeout) {
+        return new Promise(resolve => setTimeout(resolve, timeoutMs + 100))
       }
-      return msg
+      return Promise.resolve()
     })
 
     shortRpcClient.call(objectMessage)
       .then(() => done(new Error('Did not throw a timeout error')))
       .catch(() => {
+        waitForTimeout = false
         return shortRpcClient.call(objectMessage)
       })
       .then(() => done())


### PR DESCRIPTION
Tests:
- free up memory after rpc timeout
- call `done` with `Error`s if the test should fail