### PR TITLE
Fix for multi-byte characters

### DIFF
--- a/src/QueueMessage.js
+++ b/src/QueueMessage.js
@@ -37,8 +37,8 @@ class QueueMessage {
     let stringJson = JSON.stringify(obj)
     let formatBuf = Buffer.alloc(1, '+')
     let lengthBuf = Buffer.alloc(4)
-    lengthBuf.writeUInt32BE(stringJson.length)
     let jsonBuf = Buffer.from(stringJson)
+    lengthBuf.writeUInt32BE(jsonBuf.length)
     return Buffer.concat([formatBuf, lengthBuf, jsonBuf, ...attachmentBuffers])
   }
 

--- a/test/QueueMessage.test.js
+++ b/test/QueueMessage.test.js
@@ -10,7 +10,7 @@ describe('QueueMessage', () => {
   let data = 'This is a valid QueueMessage'
 
   const number = 1
-  const string = 'hello'
+  const string = 'hello ŰÁÉÚŐÓÜÖÍűáéúőóüöí$\\`#^+-[]<>*;~!%/()'
   const array = [1, 2, 3]
   const buffer = Buffer.from('test buffer')
   const object = { number, string, array, buffer }
@@ -70,8 +70,8 @@ describe('QueueMessage', () => {
     queueMessage.addAttachment('test2', Buffer.from('test2'))
     queueMessage.addAttachment('test3', Buffer.from('test3'))
     queueMessage.addAttachment('test4', Buffer.from('test4'))
-    let queueMesageBuffer = queueMessage.serialize()
-    expect(queueMesageBuffer).to.be.instanceof(Buffer)
+    let queueMessageBuffer = queueMessage.serialize()
+    expect(queueMessageBuffer).to.be.instanceof(Buffer)
   })
 
   it('#unserialize() deserialize the QueueMessage to the original QueueMessage', () => {
@@ -80,8 +80,8 @@ describe('QueueMessage', () => {
     queueMessage.addAttachment('test2', Buffer.from('test2'))
     queueMessage.addAttachment('test3', Buffer.from('test3'))
     queueMessage.addAttachment('test4', Buffer.from('test4'))
-    let queueMesageBuffer = queueMessage.serialize()
-    let newQueueMessage = QueueMessage.unserialize(queueMesageBuffer)
+    let queueMessageBuffer = queueMessage.serialize()
+    let newQueueMessage = QueueMessage.unserialize(queueMessageBuffer)
     assert.strictEqual(newQueueMessage.status, okStatus, 'status not match')
 
     let data = newQueueMessage.data

--- a/test/QueueMessage.test.js
+++ b/test/QueueMessage.test.js
@@ -10,7 +10,7 @@ describe('QueueMessage', () => {
   let data = 'This is a valid QueueMessage'
 
   const number = 1
-  const string = 'hello ŰÁÉÚŐÓÜÖÍűáéúőóüöí$\\`#^+-[]<>*;~!%/()'
+  const string = 'hello ŰÁÉÚŐÓÜÖÍűáéúőóüöí$\\`#^+-[]<>*;~!%/()孫詒讓\u1FFF\u{10FFFF}'
   const array = [1, 2, 3]
   const buffer = Buffer.from('test buffer')
   const object = { number, string, array, buffer }


### PR DESCRIPTION
Character count (`length`) of the JSON string is not equal to the length of the buffer.
That was the reason the `unserialize` method failed when we sent special characters.

```javascript
jsonString = JSON.stringify({
  key: 'ú'
})

// jsonString.length !== Buffer.from(jsonString).length
// 11 !== 12
```