### PR TITLE
Add empty object as default value for options

### DIFF
--- a/src/QueueServer.js
+++ b/src/QueueServer.js
@@ -7,7 +7,7 @@ class QueueServer extends Subscriber {
    * @param {String} name
    * @param {Object} options
    */
-  constructor (queueConnection, logger, name, options) {
+  constructor (queueConnection, logger, name, options = {}) {
     super(queueConnection, logger, name, options)
     this._prefetchCount = options.prefetchCount
   }

--- a/src/RPCServer.js
+++ b/src/RPCServer.js
@@ -11,7 +11,7 @@ class RPCServer {
    * @param {String} rpcName
    * @param {Object} options
    */
-  constructor (queueConnection, logger, rpcName, options) {
+  constructor (queueConnection, logger, rpcName, options = {}) {
     this._connection = queueConnection
     this._logger = logger
     this.name = rpcName

--- a/src/Subscriber.js
+++ b/src/Subscriber.js
@@ -7,7 +7,7 @@ class Subscriber {
    * @param {String} name
    * @param {Object} options
    */
-  constructor (queueConnection, logger, name, options) {
+  constructor (queueConnection, logger, name, options = {}) {
     this._connection = queueConnection
     this._logger = logger
     this.name = name


### PR DESCRIPTION
`prefetchCount`, `timeoutMs` and  `maxRetry` parameters are rarely used and optional parameters.
Make the whole options argument optional by adding an empty object as the default value.