### PR TITLE
RPC gathering

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,8 @@ const RPCError = require('./src/RPCError')
 const RPCServer = require('./src/RPCServer')
 const Publisher = require('./src/Publisher')
 const Subscriber = require('./src/Subscriber')
+const GatheringClient = require('./src/GatheringClient')
+const GatheringServer = require('./src/GatheringServer')
 
 module.exports.QueueClient = QueueClient
 module.exports.QueueConfig = QueueConfig
@@ -23,3 +25,5 @@ module.exports.RPCError = RPCError
 module.exports.RPCServer = RPCServer
 module.exports.Publisher = Publisher
 module.exports.Subscriber = Subscriber
+module.exports.GatheringClient = GatheringClient
+module.exports.GatheringServer = GatheringServer

--- a/src/GatheringClient.js
+++ b/src/GatheringClient.js
@@ -29,14 +29,12 @@ class GatheringClient {
       const replyQueue = await channel.assertQueue('', { exclusive: true })
       this._replyQueue = replyQueue.queue
 
-      channel.consume(this._replyQueue, (reply) => {
+      await channel.consume(this._replyQueue, (reply) => {
         this._handleGatheringResponse(reply)
-      }, { noAck: true }).catch((err) => {
-        this._logger.error('', err)
-      })
+      }, { noAck: true })
     } catch (err) {
-      this._logger.error('', err)
-      throw err
+      this._logger.error(`QUEUE GATHERING CLIENT: Error initializing '${this.name}'`)
+      throw new Error('Error initializing Gathering Client')
     }
   }
 

--- a/src/GatheringClient.js
+++ b/src/GatheringClient.js
@@ -1,0 +1,153 @@
+const { v4: uuid } = require('uuid')
+const QueueMessage = require('./QueueMessage')
+
+class GatheringClient {
+  /**
+   * @param {QueueConnection} queueConnection
+   * @param {Console} logger
+   * @param {String} name
+   */
+  constructor (queueConnection, logger, name) {
+    this._connection = queueConnection
+    this._logger = logger
+    this.name = name
+
+    this._correlationIdMap = new Map()
+    this._replyQueue = ''
+  }
+
+  async initialize () {
+    try {
+      const channel = await this._connection.getChannel()
+      await channel.assertExchange(this.name, 'fanout', { durable: true })
+
+      const replyQueue = await channel.assertQueue('', { exclusive: true })
+      this._replyQueue = replyQueue.queue
+
+      channel.consume(this._replyQueue, (reply) => {
+        this._handleGatheringResponse(reply).catch(() => {
+          // this should not throw
+        })
+      }, { noAck: true }).catch((err) => {
+        this._logger.error('', err)
+      })
+    } catch (err) {
+      this._logger.error('', err)
+      throw err
+    }
+  }
+
+  _handleGatheringResponse (reply) {
+    if (!reply || !reply.properties || !reply.properties.correlationId) {
+      this._logger.error(`QUEUE GATHERING CLIENT: INVALID REPLY ON '${this.name}': NO REPLY/PROPERTIES/CORRELATION ID`, reply)
+      return
+    }
+
+    const correlationId = reply.properties.correlationId
+
+    if (!this._correlationIdMap.has(correlationId)) {
+      this._logger.warn(`QUEUE GATHERING CLIENT: RECEIVED UNKNOWN REPLY (possibly timed out or duplicate) '${this.name}'`, correlationId)
+      return
+    }
+
+    const { resolve, reject, resolveWithFullResponse } = this._correlationIdMap.get(correlationId)
+    this._correlationIdMap.delete(correlationId)
+
+    const replyContent = QueueMessage.unserialize(reply.content)
+
+    if (replyContent.status === 'ok') {
+      if (resolveWithFullResponse) {
+        resolve(replyContent)
+      } else {
+        resolve(replyContent.data)
+      }
+    } else {
+      this._logger.error('QUEUE GATHERING CLIENT: RECEIVED ERROR REPLY', this.name, correlationId, replyContent)
+      reject(replyContent.data)
+    }
+  }
+
+  /**
+   * @param {*} data
+   * @param {Number} timeoutMs
+   * @param {Map} attachments
+   * @param {Boolean} [resolveWithFullResponse=false]
+   * @return {Promise<QueueMessage|*>}
+   * */
+  async request (data, timeoutMs = null, attachments = null, resolveWithFullResponse = false) {
+    if (this._correlationIdMap.size > this._rpcQueueMaxSize) {
+      throw new Error(`QUEUE GATHERING CLIENT: REQUEST LIMIT REACHED '${this.name}'`)
+    }
+
+    try {
+      const channel = await this._connection.getChannel()
+
+      const param = new QueueMessage('ok', data, timeoutMs)
+      if (attachments instanceof Map) {
+        for (const [key, value] of attachments) {
+          param.addAttachment(key, value)
+        }
+      }
+
+      return await new Promise((resolve, reject) => {
+        const correlationId = this._registerMessage(resolve, reject, timeoutMs, resolveWithFullResponse)
+
+        channel.sendToQueue(this.name, param.serialize(), {
+          correlationId: correlationId,
+          replyTo: this._replyQueue
+        })
+      })
+    } catch (err) {
+      this._logger.error('QUEUE GATHERING CLIENT: failed to send message', err)
+      throw new Error(`QUEUE GATHERING CLIENT: failed to send message ${err.message}`)
+    }
+  }
+
+  /**
+   * @param {Function} resolve
+   * @param {Function} reject
+   * @param {Number} timeoutMs
+   * @param {boolean} resolveWithFullResponse
+   * @return {Number} correlation id
+   * @private
+   */
+  _registerMessage (resolve, reject, timeoutMs, resolveWithFullResponse) {
+    let correlationId
+    let timeoutId
+
+    do {
+      correlationId = uuid()
+    } while (this._correlationIdMap.has(correlationId))
+
+    this._correlationIdMap.set(correlationId, {
+      resolveWithFullResponse: resolveWithFullResponse,
+      resolve: (result) => {
+        if (timeoutId) {
+          clearTimeout(timeoutId)
+          timeoutId = null
+          resolve(result)
+        }
+      },
+      reject: (err) => {
+        if (timeoutId) {
+          clearTimeout(timeoutId)
+          timeoutId = null
+          reject(err)
+        }
+      }
+    })
+
+    timeoutId = setTimeout(() => {
+      timeoutId = null
+      if (this._correlationIdMap.has(correlationId)) {
+        this._correlationIdMap.delete(correlationId)
+
+        reject(new Error(`QUEUE GATHERING RESPONSE TIMED OUT '${this.name}' ${correlationId}`))
+      }
+    }, timeoutMs || this._rpcTimeoutMs)
+
+    return correlationId
+  }
+}
+
+module.exports = GatheringClient

--- a/src/GatheringClient.js
+++ b/src/GatheringClient.js
@@ -12,13 +12,15 @@ class GatheringClient {
     this._connection = queueConnection
     this._logger = logger
     this.name = name
+    this.statusQueue = name
 
     this._correlationIdMap = new Map()
     this._replyQueue = ''
 
-    const { queueMaxSize, timeoutMs } = options
+    const { queueMaxSize, timeoutMs, serverCount = 0 } = options
     this._rpcQueueMaxSize = queueMaxSize
     this._rpcTimeoutMs = timeoutMs
+    this._gatheringServerCount = serverCount
   }
 
   async initialize () {
@@ -30,8 +32,30 @@ class GatheringClient {
       this._replyQueue = replyQueue.queue
 
       await channel.consume(this._replyQueue, (reply) => {
-        this._handleGatheringResponse(reply)
+        if (!reply) {
+          this._logger.error(`QUEUE GATHERING CLIENT: INVALID REPLY ON '${this.name}': NO REPLY`, reply)
+          return
+        }
+        if (!reply.properties) {
+          this._logger.error(`QUEUE GATHERING CLIENT: INVALID REPLY ON '${this.name}': NO PROPERTIES ON REPLY`, reply)
+          return
+        }
+        if (!reply.properties.correlationId) {
+          this._logger.error(`QUEUE GATHERING CLIENT: INVALID REPLY ON '${this.name}': NO CORRELATION ID ON REPLY`, reply)
+          return
+        }
+
+        if (reply.properties.type === 'status') {
+          this._handleStatusResponse(reply)
+        } else {
+          this._handleGatheringResponse(reply)
+        }
       }, { noAck: true })
+
+      // await channel.assertQueue(this.statusQueue, { exclusive: false, autoDelete: true })
+      // await channel.consume(this.statusQueue, (reply) => {
+      //   this._handleStatusResponse(reply)
+      // }, { noAck: true })
     } catch (err) {
       this._logger.error(`QUEUE GATHERING CLIENT: Error initializing '${this.name}'`)
       throw new Error('Error initializing Gathering Client')
@@ -43,55 +67,57 @@ class GatheringClient {
    * @param {Number} timeoutMs
    * @param {Map} attachments
    * @param {Boolean} [resolveWithFullResponse=false]
+   * @param {Boolean} [acceptNotFound=true]
    * @return {Promise<QueueMessage|*>}
    * */
-  async request (data, timeoutMs = null, attachments = null, resolveWithFullResponse = false) {
+  async request (data, timeoutMs = null, attachments = null, resolveWithFullResponse = false, acceptNotFound = true) {
     if (this._correlationIdMap.size > this._rpcQueueMaxSize) {
       throw new Error(`QUEUE GATHERING CLIENT: REQUEST LIMIT REACHED '${this.name}'`)
     }
 
-    try {
-      const channel = await this._connection.getChannel()
+    const channel = await this._connection.getChannel()
+    const statusQueue = await channel.assertQueue(this.statusQueue, {
+      exclusive: false,
+      autoDelete: true
+    })
+    const serverCount = statusQueue.consumerCount
 
-      const param = new QueueMessage('ok', data, timeoutMs)
-      if (attachments instanceof Map) {
-        for (const [key, value] of attachments) {
-          param.addAttachment(key, value)
-        }
+    const param = new QueueMessage('ok', data, timeoutMs)
+    if (attachments instanceof Map) {
+      for (const [key, value] of attachments) {
+        param.addAttachment(key, value)
+      }
+    }
+
+    return new Promise((resolve, reject) => {
+      const correlationId = this._registerMessage(resolve, reject, timeoutMs, resolveWithFullResponse, acceptNotFound, serverCount)
+      const options = {
+        correlationId: correlationId,
+        replyTo: this._replyQueue
       }
 
-      return await new Promise((resolve, reject) => {
-        const correlationId = this._registerMessage(resolve, reject, timeoutMs, resolveWithFullResponse)
-        const options = {
-          correlationId: correlationId,
-          replyTo: this._replyQueue
-        }
-
-        try {
-          const isWriteBufferEmpty = channel.publish(this.name, '', param.serialize(), options, (err) => {
-            if (err) {
-              if (this._correlationIdMap.has(correlationId)) {
-                this._correlationIdMap.delete(correlationId)
-              }
-              this._logger.error('QUEUE GATHERING CLIENT: failed to publish message', err)
-              reject(new Error('channel.publish failed'))
+      try {
+        const isWriteBufferEmpty = channel.publish(this.name, '', param.serialize(), options, (err) => {
+          if (err) {
+            if (this._correlationIdMap.has(correlationId)) {
+              this._correlationIdMap.delete(correlationId)
             }
-          })
+            this._logger.error('QUEUE GATHERING CLIENT: failed to publish message', err)
+            reject(new Error('channel.publish failed'))
+          }
+        })
 
-          if (!isWriteBufferEmpty) { // http://www.squaremobius.net/amqp.node/channel_api.html#channel_publish
-            channel.on('drain', resolve)
-          }
-        } catch (err) {
-          if (this._correlationIdMap.has(correlationId)) {
-            this._correlationIdMap.delete(correlationId)
-          }
-          reject(err)
+        if (!isWriteBufferEmpty) { // http://www.squaremobius.net/amqp.node/channel_api.html#channel_publish
+          channel.on('drain', resolve)
         }
-      })
-    } catch (err) {
-      this._logger.error('QUEUE GATHERING CLIENT: failed to send message', err)
-      throw new Error(`QUEUE GATHERING CLIENT: failed to send message ${err.message}`)
-    }
+      } catch (err) {
+        if (this._correlationIdMap.has(correlationId)) {
+          this._correlationIdMap.delete(correlationId)
+        }
+        this._logger.error('QUEUE GATHERING CLIENT: failed to send message', err)
+        reject(err)
+      }
+    })
   }
 
   /**
@@ -99,10 +125,12 @@ class GatheringClient {
    * @param {Function} reject
    * @param {Number} timeoutMs
    * @param {boolean} resolveWithFullResponse
+   * @param {boolean} acceptNotFound
+   * @param {Number} serverCount
    * @return {Number} correlation id
    * @private
    */
-  _registerMessage (resolve, reject, timeoutMs, resolveWithFullResponse) {
+  _registerMessage (resolve, reject, timeoutMs, resolveWithFullResponse, acceptNotFound, serverCount) {
     let correlationId
     let timeoutId
     let timedOut = false
@@ -113,6 +141,9 @@ class GatheringClient {
 
     this._correlationIdMap.set(correlationId, {
       resolveWithFullResponse: resolveWithFullResponse,
+      acceptNotFound: acceptNotFound,
+      serverCount: serverCount || this._gatheringServerCount,
+      responseCount: 0,
       resolve: (result) => {
         if (!timedOut) {
           clearTimeout(timeoutId)
@@ -132,9 +163,11 @@ class GatheringClient {
     timeoutId = setTimeout(() => {
       timedOut = true
       if (this._correlationIdMap.has(correlationId)) {
+        const requestData = this._correlationIdMap.get(correlationId)
+        const { serverCount, responseCount } = requestData || {}
         this._correlationIdMap.delete(correlationId)
 
-        reject(new Error(`QUEUE GATHERING RESPONSE TIMED OUT '${this.name}' ${correlationId}`))
+        reject(new Error(`QUEUE GATHERING RESPONSE TIMED OUT '${this.name}' ${correlationId} ${responseCount}/${serverCount}`))
       }
     }, timeoutMs || this._rpcTimeoutMs)
 
@@ -142,19 +175,16 @@ class GatheringClient {
   }
 
   _handleGatheringResponse (reply) {
-    if (!reply || !reply.properties || !reply.properties.correlationId) {
-      this._logger.error(`QUEUE GATHERING CLIENT: INVALID REPLY ON '${this.name}': NO REPLY/PROPERTIES/CORRELATION ID`, reply)
-      return
-    }
-
     const correlationId = reply.properties.correlationId
 
     if (!this._correlationIdMap.has(correlationId)) {
-      this._logger.warn(`QUEUE GATHERING CLIENT: RECEIVED UNKNOWN REPLY (possibly timed out or duplicate) '${this.name}'`, correlationId)
+      this._logger.warn(`QUEUE GATHERING CLIENT: RECEIVED UNKNOWN REPLY (possibly timed out) '${this.name}'`, correlationId)
       return
     }
 
-    const { resolve, reject, resolveWithFullResponse } = this._correlationIdMap.get(correlationId)
+    const requestData = this._correlationIdMap.get(correlationId)
+    const { resolve, reject, resolveWithFullResponse } = requestData || {}
+
     this._correlationIdMap.delete(correlationId)
 
     const replyContent = QueueMessage.unserialize(reply.content)
@@ -168,6 +198,29 @@ class GatheringClient {
     } else {
       this._logger.error('QUEUE GATHERING CLIENT: RECEIVED ERROR REPLY', this.name, correlationId, replyContent)
       reject(replyContent.data)
+    }
+  }
+
+  _handleStatusResponse (reply) {
+    const correlationId = reply.properties.correlationId
+
+    if (!this._correlationIdMap.has(correlationId)) {
+      return
+    }
+
+    const requestData = this._correlationIdMap.get(correlationId)
+    const { resolve, reject, acceptNotFound, serverCount, responseCount } = requestData || {}
+
+    requestData.responseCount++
+    this._correlationIdMap.set(correlationId, requestData)
+
+    if (requestData.responseCount >= serverCount) {
+      this._correlationIdMap.delete(correlationId)
+      if (acceptNotFound) {
+        resolve()
+      } else {
+        reject(new Error(`Gathering failed: resource not found ${responseCount}/${serverCount}`))
+      }
     }
   }
 }

--- a/src/GatheringClient.js
+++ b/src/GatheringClient.js
@@ -197,7 +197,7 @@ class GatheringClient {
     const correlationId = reply.properties.correlationId
 
     if (!this._correlationIdMap.has(correlationId)) {
-      this._logger.warn(`QUEUE GATHERING CLIENT: RECEIVED UNKNOWN REPLY (possibly timed out) '${this.name}'`, correlationId)
+      this._logger.warn(`QUEUE GATHERING CLIENT: RECEIVED UNKNOWN REPLY (possibly timed out or already received) '${this.name}'`, correlationId)
       return
     }
 

--- a/src/GatheringServer.js
+++ b/src/GatheringServer.js
@@ -1,0 +1,208 @@
+const QueueMessage = require('./QueueMessage')
+const QueueResponse = require('./QueueResponse')
+
+class GatheringServer {
+  /**
+   * @param {QueueConnection} queueConnection
+   * @param {Console} logger
+   * @param {String} exchange
+   * @param {Object} options
+   */
+  constructor (queueConnection, logger, exchange, options) {
+    this._connection = queueConnection
+    this._logger = logger
+    this.exchange = exchange
+
+    const { timeoutMs } = options || {}
+    this._responseTimeoutMs = timeoutMs
+
+    this.actions = new Map()
+  }
+
+  async initialize () {
+    try {
+      const channel = await this._connection.getChannel()
+      await channel.assertExchange(this.name, 'fanout', { durable: true })
+      const serverQueue = await channel.assertQueue('', { exclusive: true })
+
+      await channel.bindQueue(serverQueue.queue, this.name, '')
+
+      await channel.consume(serverQueue.queue, (msg) => {
+        this._handleGatheringAnnouncement(channel, msg).catch(() => {
+          // this should not throw
+        })
+      }, { noAck: true })
+    } catch (err) {
+      this._logger.error('CANNOT INITIALIZE QUEUE GATHERING SERVER', err)
+    }
+  }
+
+  /**
+   * @param {*} msg
+   * @param {QueueMessage} request
+   * @param {QueueResponse} response
+   * @protected
+   * @returns {Promise}
+   */
+  async _callback (msg, request, response) {
+    const {
+      action,
+      data
+    } = msg || {}
+    if (!this.actions.has(action)) {
+      return Promise.resolve()
+    }
+
+    const handler = this.actions.get(action)
+
+    return handler.call(this, data, request, response)
+  }
+
+  /**
+   * @param {string} action
+   * @param {Function} handler
+   */
+  registerAction (action, handler) {
+    if (typeof handler !== 'function') {
+      throw new TypeError(`${typeof handler} is not a Function`)
+    } else if (this.actions.has(action)) {
+      this._logger.warn(`Actions-handlers map already contains an action named ${action}`)
+    } else {
+      this.actions.set(action, handler)
+    }
+  }
+
+  /**
+   * @param {Function} cb
+   */
+  consume (cb) {
+    this._callback = cb
+  }
+
+  /**
+   * @param channel
+   * @param msg
+   * @return {Promise}
+   * @private
+   */
+  async _handleGatheringAnnouncement (channel, msg) {
+    if (!msg || !msg.properties) {
+      this._logger.error(`QUEUE GATHERING SERVER: INVALID REQUEST ON '${this.name}': NO MESSAGE/PROPERTIES`, msg)
+      this._nack(channel, msg)
+      return
+    }
+    if (!msg.properties.correlationId) {
+      this._logger.error(`QUEUE GATHERING SERVER: INVALID REQUEST ON '${this.name}': NO CORRELATION ID`, msg)
+      this._nack(channel, msg)
+      return
+    }
+    if (!msg.properties.replyTo) {
+      this._logger.error(`QUEUE GATHERING SERVER: INVALID REQUEST ON '${this.name}': NO REPLY TO`, msg)
+      this._nack(channel, msg)
+      return
+    }
+
+    const correlationId = msg.properties.correlationId
+    const replyTo = msg.properties.replyTo
+    let request
+
+    try {
+      request = QueueMessage.unserialize(msg.content)
+      if (request.status !== 'ok') {
+        this._logger.error(`QUEUE GATHERING SERVER: MESSAGE NOT OK '${this.name}' ${correlationId}`, request)
+        this._nack(channel, msg)
+        return
+      }
+    } catch (err) {
+      this._logger.error(`QUEUE GATHERING SERVER: MALFORMED MESSAGE '${this.name}' ${correlationId}`, err)
+      this._nack(channel, msg)
+      return
+    }
+
+    let responseTimedOut = false
+    const response = new QueueResponse()
+    const timeoutMs = typeof request.timeOut === 'number' ? request.timeOut : this._responseTimeoutMs
+    const timerId = setTimeout(() => {
+      responseTimedOut = true
+      this._logger.error(`QUEUE GATHERING SERVER: RESPONSE TIMED OUT '${this.name}' ${correlationId}`)
+      this._nack(channel, msg)
+    }, timeoutMs)
+
+    let answer
+    try {
+      answer = await this._callback(request.data, request, response)
+    } catch (err) {
+      this._logger.error(`QUEUE GATHERING SERVER: response failed '${this.name}' ${correlationId}`)
+      this._nack(channel, msg)
+      return
+    }
+
+    if (responseTimedOut) {
+      return
+    }
+
+    clearTimeout(timerId)
+
+    if (!response.statusCode && typeof answer !== 'undefined') {
+      // implicit status
+      response.setStatus(response.OK)
+    }
+
+    let reply
+    try {
+      if (response.statusCode === response.OK) {
+        const replyAttachments = response.getAttachments()
+        reply = new QueueMessage('ok', answer)
+        if (replyAttachments instanceof Map) {
+          for (const [key, value] of replyAttachments) {
+            reply.addAttachment(key, value)
+          }
+        }
+      } else if (response.statusCode === response.NOT_FOUND) {
+        this._nack(channel, msg)
+      } else if (response.statusCode === response.ERROR) {
+        reply = new QueueMessage('error', response.statusMessage)
+      }
+    } catch (err) {
+      this._logger.error('QUEUE GATHERING SERVER: Failed to construct reply', this.name, err)
+    }
+
+    try {
+      channel.sendToQueue(replyTo, reply.serialize(), { correlationId: correlationId })
+      this._ack(channel, msg)
+    } catch (err) {
+      this._logger.error('QUEUE GATHERING SERVER: Failed to send reply', this.name, err)
+    }
+  }
+
+  /**
+   * @param ch
+   * @param msg
+   * @private
+   */
+  _ack (ch, msg) {
+    if (msg.acked) {
+      this._logger.error('trying to double ack', msg)
+      return
+    }
+    ch.ack(msg)
+    msg.acked = true
+  }
+
+  /**
+   * @param channel
+   * @param msg
+   * @param [requeue=true]
+   * @private
+   */
+  _nack (channel, msg, requeue = true) {
+    if (msg.acked) {
+      this._logger.error('trying to double nack', msg)
+      return
+    }
+    channel.nack(msg, false, requeue)
+    msg.acked = true
+  }
+}
+
+module.exports = GatheringServer

--- a/src/GatheringServer.js
+++ b/src/GatheringServer.js
@@ -169,7 +169,7 @@ class GatheringServer {
 
     try {
       channel.sendToQueue(replyTo, reply.serialize(), { correlationId: correlationId })
-      this._ack(channel, msg)
+      // this._ack(channel, msg)
     } catch (err) {
       this._logger.error('QUEUE GATHERING SERVER: Failed to send reply', this.name, err)
     }

--- a/src/GatheringServer.js
+++ b/src/GatheringServer.js
@@ -25,11 +25,12 @@ class GatheringServer {
       const channel = await this._connection.getChannel()
       await channel.assertExchange(this.name, 'fanout', { durable: true })
       const serverQueue = await channel.assertQueue('', { exclusive: true })
+      const serverQueueName = serverQueue.queue
 
       await channel.prefetch(this._prefetchCount)
-      await channel.bindQueue(serverQueue.queue, this.name, '')
+      await channel.bindQueue(serverQueueName, this.name, '')
 
-      await channel.consume(serverQueue.queue, (msg) => {
+      await channel.consume(serverQueueName, (msg) => {
         this._handleGatheringAnnouncement(channel, msg).catch(() => {
           // this should not throw
         })

--- a/src/GatheringServer.js
+++ b/src/GatheringServer.js
@@ -31,7 +31,7 @@ class GatheringServer {
         this._handleGatheringAnnouncement(channel, msg).catch(() => {
           // this should not throw
         })
-      }, { noAck: true })
+      })
     } catch (err) {
       this._logger.error('CANNOT INITIALIZE QUEUE GATHERING SERVER', err)
     }

--- a/src/GatheringServer.js
+++ b/src/GatheringServer.js
@@ -11,7 +11,7 @@ class GatheringServer {
   constructor (queueConnection, logger, exchange, options) {
     this._connection = queueConnection
     this._logger = logger
-    this.exchange = exchange
+    this.name = exchange
 
     const { timeoutMs } = options || {}
     this._responseTimeoutMs = timeoutMs

--- a/src/GatheringServer.js
+++ b/src/GatheringServer.js
@@ -169,7 +169,7 @@ class GatheringServer {
 
     try {
       channel.sendToQueue(replyTo, reply.serialize(), { correlationId: correlationId })
-      // this._ack(channel, msg)
+      this._ack(channel, msg)
     } catch (err) {
       this._logger.error('QUEUE GATHERING SERVER: Failed to send reply', this.name, err)
     }

--- a/src/GatheringServer.js
+++ b/src/GatheringServer.js
@@ -33,7 +33,8 @@ class GatheringServer {
         })
       })
     } catch (err) {
-      this._logger.error('CANNOT INITIALIZE QUEUE GATHERING SERVER', err)
+      this._logger.error('CANNOT INITIALIZE QUEUE GATHERING SERVER', this.name, err)
+      throw new Error('Error initializing Gathering Server')
     }
   }
 

--- a/src/GatheringServer.js
+++ b/src/GatheringServer.js
@@ -13,7 +13,8 @@ class GatheringServer {
     this._logger = logger
     this.name = exchange
 
-    const { timeoutMs } = options || {}
+    const { prefetchCount, timeoutMs } = options || {}
+    this._prefetchCount = prefetchCount
     this._responseTimeoutMs = timeoutMs
 
     this.actions = new Map()
@@ -25,6 +26,7 @@ class GatheringServer {
       await channel.assertExchange(this.name, 'fanout', { durable: true })
       const serverQueue = await channel.assertQueue('', { exclusive: true })
 
+      await channel.prefetch(this._prefetchCount)
       await channel.bindQueue(serverQueue.queue, this.name, '')
 
       await channel.consume(serverQueue.queue, (msg) => {

--- a/src/GatheringServer.js
+++ b/src/GatheringServer.js
@@ -160,11 +160,14 @@ class GatheringServer {
         }
       } else if (response.statusCode === response.NOT_FOUND) {
         this._nack(channel, msg)
+        return
       } else if (response.statusCode === response.ERROR) {
         reply = new QueueMessage('error', response.statusMessage)
       }
     } catch (err) {
       this._logger.error('QUEUE GATHERING SERVER: Failed to construct reply', this.name, err)
+      this._nack(channel, msg)
+      return
     }
 
     try {

--- a/src/QueueManager.js
+++ b/src/QueueManager.js
@@ -216,18 +216,24 @@ class QueueManager {
   /**
    * @param {String} exchangeName
    * @param {GatheringClient|function() : GatheringClient} OverrideClass
+   * @param {Object} [options]
    * @return GatheringClient
    */
-  getGatheringClient (exchangeName, OverrideClass = GatheringClient) {
+  getGatheringClient (exchangeName, OverrideClass = GatheringClient, options = {}) {
     if (this.gatheringClients.has(exchangeName)) {
       return this.gatheringClients.get(exchangeName)
+    }
+
+    if (arguments.length === 2 && typeof OverrideClass !== 'function') {
+      options = OverrideClass
+      OverrideClass = GatheringClient
     }
 
     if (OverrideClass !== GatheringClient && !(OverrideClass.prototype instanceof GatheringClient)) {
       throw new Error('Override must be a subclass of GatheringClient')
     }
 
-    const gatheringClient = new OverrideClass(this.connection, this._logger, exchangeName)
+    const gatheringClient = new OverrideClass(this.connection, this._logger, exchangeName, options)
 
     this.gatheringClients.set(exchangeName, gatheringClient)
 

--- a/src/QueueManager.js
+++ b/src/QueueManager.js
@@ -216,7 +216,7 @@ class QueueManager {
   /**
    * @param {String} exchangeName
    * @param {GatheringClient|function() : GatheringClient} OverrideClass
-   * @return Publisher
+   * @return GatheringClient
    */
   getGatheringClient (exchangeName, OverrideClass = GatheringClient) {
     if (this.gatheringClients.has(exchangeName)) {
@@ -238,7 +238,7 @@ class QueueManager {
    * @param {String} exchangeName
    * @param {GatheringServer|function() : GatheringServer} OverrideClass
    * @param {Object} [options]
-   * @return Subscriber
+   * @return GatheringServer
    */
   getGatheringServer (exchangeName, OverrideClass = GatheringServer, options = {}) {
     if (this.gatheringServers.has(exchangeName)) {
@@ -255,8 +255,6 @@ class QueueManager {
     }
 
     const settings = Object.assign({
-      prefetchCount: 1,
-      maxRetry: 5,
       timeoutMs: this._config.rpcTimeoutMs
     }, options)
 

--- a/test/Gathering-multi-server.test.js
+++ b/test/Gathering-multi-server.test.js
@@ -5,7 +5,7 @@ const config = require('./config/LoadConfig')
 
 describe('GatheringClient && multiple GatheringServer', () => {
   const gatheringName = 'test-gathering-multi'
-  const logger = /*new ConsoleInspector*/(console)
+  const logger = new ConsoleInspector(console)
   const timeoutMs = 1000
 
   const queueManager = new QueueManager(config)
@@ -24,7 +24,7 @@ describe('GatheringClient && multiple GatheringServer', () => {
   })
 
   after(() => {
-    // logger.empty()
+    logger.empty()
   })
 
   it('GatheringClient.request() sends something and one of the GatheringServers reply in time with setting ok response status', (done) => {

--- a/test/Gathering-multi-server.test.js
+++ b/test/Gathering-multi-server.test.js
@@ -1,0 +1,114 @@
+const QueueManager = require('../src/QueueManager')
+const GatheringServer = require('../src/GatheringServer')
+const ConsoleInspector = require('./consoleInspector')
+const config = require('./config/LoadConfig')
+
+describe('GatheringClient && multiple GatheringServer', () => {
+  const gatheringName = 'test-gathering-multi'
+  const logger = /*new ConsoleInspector*/(console)
+  const timeoutMs = 1000
+
+  const queueManager = new QueueManager(config)
+  queueManager.setLogger(logger)
+
+  const gatheringClient = queueManager.getGatheringClient(gatheringName, { queueMaxSize: 100, timeoutMs })
+  const gatheringServer1 = new GatheringServer(queueManager.connection, queueManager._logger, gatheringName, { prefetchCount: 1, timeoutMs })
+  const gatheringServer2 = new GatheringServer(queueManager.connection, queueManager._logger, gatheringName, { prefetchCount: 1, timeoutMs })
+
+  before(() => {
+    return queueManager.connect().then(() => {
+      return gatheringServer1.initialize()
+    }).then(() => {
+      return gatheringServer2.initialize()
+    })
+  })
+
+  after(() => {
+    // logger.empty()
+  })
+
+  it('GatheringClient.request() sends something and one of the GatheringServers reply in time with setting ok response status', (done) => {
+    const messageBody = 'hello'
+    gatheringServer1.consume((msg, message, response) => {
+      response.setStatus(response.NOT_FOUND)
+    })
+    gatheringServer2.consume((msg, message, response) => {
+      response.setStatus(response.OK)
+      return msg
+    })
+
+    gatheringClient.request(messageBody, 10000).then((res) => {
+      done()
+    }).catch((err) => {
+      done(err)
+    })
+  })
+
+  it('GatheringClient.request() sends something and one of the GatheringServers reply in time with implied ok response status', (done) => {
+    const messageBody = 'hello'
+    gatheringServer1.consume((msg, message, response) => {
+      response.setStatus(response.NOT_FOUND)
+    })
+    gatheringServer2.consume((msg) => {
+      return msg
+    })
+
+    gatheringClient.request(messageBody, 10000).then((res) => {
+      done()
+    }).catch((err) => {
+      done(err)
+    })
+  })
+
+  it('GatheringClient.request() sends something and every GatheringServer replies with not_found status', (done) => {
+    const messageBody = 'hello'
+    gatheringServer1.consume((msg, message, response) => {
+      response.setStatus(response.NOT_FOUND)
+    })
+    gatheringServer2.consume((msg, message, response) => {
+      response.setStatus(response.NOT_FOUND)
+    })
+
+    gatheringClient.request(messageBody, 10000).then((res) => {
+      done()
+    }).catch((err) => {
+      done(err)
+    })
+  })
+
+  it('GatheringServer.consume() undefined reply implies not_found status and request resolves with undefined', (done) => {
+    const messageBody = 'hello'
+    gatheringServer1.consume(() => {
+      // undefined is implied not found
+    })
+    gatheringServer2.consume(() => {
+      // undefined is implied not found
+    })
+
+    gatheringClient.request(messageBody, 10000).then((res) => {
+      if (typeof res === 'undefined') {
+        done()
+      } else {
+        done(new Error('Should have resolved with undefined'))
+      }
+    }).catch((err) => {
+      done(err)
+    })
+  })
+
+  it('gatheringClient.request(acceptNotFound=false) rejects not found statuses', (done) => {
+    const messageBody = 'hello'
+    gatheringServer1.consume(() => {
+      // undefined is implied not found
+    })
+    gatheringServer2.consume(() => {
+      // undefined is implied not found
+    })
+
+    gatheringClient.request(messageBody, 10000, null, false, false).then((res) => {
+      done(new Error('Should reject not found with acceptNotFound=false'))
+    }).catch(() => {
+      done()
+    })
+  })
+})

--- a/test/Gathering-multi-server.test.js
+++ b/test/Gathering-multi-server.test.js
@@ -5,7 +5,7 @@ const config = require('./config/LoadConfig')
 
 describe('GatheringClient && multiple GatheringServer', () => {
   const gatheringName = 'test-gathering-multi'
-  const logger = new ConsoleInspector(console)
+  const logger = /*new ConsoleInspector*/(console)
   const timeoutMs = 1000
 
   const queueManager = new QueueManager(config)
@@ -24,7 +24,7 @@ describe('GatheringClient && multiple GatheringServer', () => {
   })
 
   after(() => {
-    logger.empty()
+    // logger.empty()
   })
 
   it('GatheringClient.request() sends something and one of the GatheringServers reply in time with setting ok response status', (done) => {
@@ -71,6 +71,27 @@ describe('GatheringClient && multiple GatheringServer', () => {
 
     gatheringClient.request(messageBody, 10000).then((res) => {
       done()
+    }).catch((err) => {
+      done(err)
+    })
+  })
+
+  it('GatheringClient.request() sends something and every GatheringServer replies with ok status', (done) => {
+    const stringMessage = 'hello'
+    gatheringServer1.consume(() => {
+      return stringMessage
+    })
+    gatheringServer2.consume(() => {
+      return stringMessage
+    })
+
+    gatheringClient.request(stringMessage, 10000).then((msg) => {
+      if (msg === stringMessage) {
+        done()
+      } else {
+        done(new Error('String received is not the same as the String sent'))
+      }
+      return true
     }).catch((err) => {
       done(err)
     })

--- a/test/Gathering.test.js
+++ b/test/Gathering.test.js
@@ -1,0 +1,166 @@
+const QueueManager = require('../src/QueueManager')
+const ConsoleInspector = require('./consoleInspector')
+const SeedRandom = require('seed-random')
+const config = require('./config/LoadConfig')
+
+describe('GatheringClient && GatheringServer', () => {
+  const gatheringName = 'test-gathering'
+  // const shortGatheringName = 'short-test-gathering'
+  const logger = /*new ConsoleInspector*/(console)
+  const timeoutMs = 1000
+
+  const queueManager = new QueueManager(config)
+  queueManager.setLogger(logger)
+
+  const gatheringClient = queueManager.getGatheringClient(gatheringName, { queueMaxSize: 100, timeoutMs })
+  const gatheringServer1 = queueManager.getGatheringServer(gatheringName, { /* queueMaxSize: 100, */ timeoutMs })
+  // const gatheringServer2 = queueManager.getGatheringServer(gatheringName, { /* queueMaxSize: 100, */ timeoutMs })
+
+  before(() => {
+    return queueManager.connect()
+  })
+
+  after(() => {
+    // logger.empty()
+  })
+
+  it('GatheringClient.request() sends a STRING and GatheringServer.consume() receives it', (done) => {
+    const stringMessage = 'foobar'
+    gatheringServer1.consume((msg) => {
+      if (msg === stringMessage) {
+        done()
+      } else {
+        done(new Error('String received is not the same as the String sent'))
+      }
+      return true
+    })
+    gatheringClient.request(stringMessage, 10000).catch((err) => {
+      done(err)
+    })
+  })
+
+  it('GatheringClient.request() sends an OBJECT and GatheringServer.consume() receives it', (done) => {
+    const objectMessage = { foo: 'bar', bar: 'foo' }
+    gatheringServer1.consume((msg) => {
+      if (JSON.stringify(msg) === JSON.stringify(objectMessage)) {
+        done()
+      } else {
+        done(new Error('The send OBJECT is not equal to the received one'))
+      }
+      return true
+    })
+    gatheringClient.request(objectMessage, 10000).catch((err) => {
+      done(err)
+    })
+  })
+
+  it('GatheringClient.request() sends an OBJECT, RPCServer.consume() sends it back and GatheringClient receives it intact', (done) => {
+    const objectMessage = { foo: 'bar', bar: 'foo' }
+    gatheringServer1.consume((msg) => {
+      return msg
+    })
+    gatheringClient.request(objectMessage, 10000).then((res) => {
+      if (JSON.stringify(res) === JSON.stringify(objectMessage)) {
+        done()
+      } else {
+        done(new Error(`Object sent and received are not equal: ${JSON.stringify(res)}`))
+      }
+    }).catch((err) => {
+      done(err)
+    })
+  })
+
+  it('GatheringClient.request() sends an OBJECT, RPCServer.consume() sends back a response' +
+    'with a 100MB random generated buffer and GatheringClient receives it', (done) => {
+    const objectMessage = { foo: 'bar', bar: 'foo' }
+
+    const rand = SeedRandom()
+    const buf = Buffer.alloc(102400)
+    for (let i = 0; i < 102400; ++i) {
+      buf[i] = (rand() * 255) << 0
+    }
+
+    gatheringServer1.consume((msg, request, response) => {
+      response.addAttachment('test', buf)
+      if (!response.hasAnyAttachments()) {
+        done(new Error('Missing attachment from response'))
+      }
+      if (!response.hasAttachment('test')) {
+        done(new Error('Missing attachment name "test" from response'))
+      }
+      if (!response.getAttachment('test') === buf) {
+        done(new Error('Attachment name "test" is not the same'))
+      }
+      return msg
+    })
+    gatheringClient.request(objectMessage, 10000, null, true).then((res) => {
+      if (!res.hasAttachment('test')) {
+        done(new Error('Missing attachment from reply'))
+      } else if (!(res.getAttachment('test') instanceof Buffer)) {
+        done(new Error('Attachment is not a buffer'))
+      } else if (res.getAttachment('test').toString() !== buf.toString()) {
+        done(new Error('String received is not the same as the String sent'))
+      } else {
+        done()
+      }
+    }).catch((err) => {
+      done(err)
+    })
+  })
+
+  it('gatheringClient.request() sends a message with a 100MB random generated buffer and gatheringServer1.consume() receives it', function (done) {
+    const stringMessage = 'foobar'
+    const attachments = new Map()
+
+    const rand = SeedRandom()
+    const buf = Buffer.alloc(102400)
+
+    for (let i = 0; i < 102400; ++i) {
+      buf[i] = (rand() * 255) << 0
+    }
+
+    attachments.set('test', buf)
+
+    gatheringServer1.consume((msg, queueMessage) => {
+      if (queueMessage.getAttachments().get('test').toString() !== buf.toString()) {
+        done(new Error('String received is not the same as the String sent'))
+        return true
+      }
+      done()
+      return true
+    })
+
+    gatheringClient.request(stringMessage, null, attachments).catch((err) => {
+      done(err)
+    })
+  })
+
+  it('GatheringClient.request() throws an error when the parameter cant be JSON-serialized', (done) => {
+    const nonJSONSerializableMessage = {}
+    nonJSONSerializableMessage.a = { b: nonJSONSerializableMessage }
+
+    gatheringServer1.consume((msg) => {
+      done(new Error('Should not receive the message'))
+      return true
+    })
+
+    gatheringClient.request(nonJSONSerializableMessage)
+      .then(() => done(new Error('Did not throw an error')))
+      .catch(() => done())
+  })
+
+  it(`GatheringClient.request() throws an error if it doesn't receive a response sooner than ${timeoutMs}ms`, (done) => {
+    const objectMessage = { foo: 'bar', bar: 'foo' }
+
+    gatheringServer1.consume((msg) => {
+      const now = Date.now()
+      // eslint-disable-next-line no-empty
+      while (new Date().getTime() < now + timeoutMs + 100) { }
+      return msg
+    })
+
+    gatheringClient.request(objectMessage)
+      .then(() => done(new Error('Did not throw a timeout error')))
+      .catch(() => done())
+  })
+})

--- a/test/Gathering.test.js
+++ b/test/Gathering.test.js
@@ -5,8 +5,7 @@ const config = require('./config/LoadConfig')
 
 describe('GatheringClient && GatheringServer', () => {
   const gatheringName = 'test-gathering'
-  // const shortGatheringName = 'short-test-gathering'
-  const logger = /*new ConsoleInspector*/(console)
+  const logger = new ConsoleInspector(console)
   const timeoutMs = 1000
 
   const queueManager = new QueueManager(config)

--- a/test/Gathering.test.js
+++ b/test/Gathering.test.js
@@ -52,7 +52,7 @@ describe('GatheringClient && GatheringServer', () => {
     })
   })
 
-  it('GatheringClient.request() sends an OBJECT, RPCServer.consume() sends it back and GatheringClient receives it intact', (done) => {
+  it('GatheringClient.request() sends an OBJECT, GatheringServer.consume() sends it back and GatheringClient receives it intact', (done) => {
     const objectMessage = { foo: 'bar', bar: 'foo' }
     gatheringServer1.consume((msg) => {
       return msg
@@ -68,7 +68,7 @@ describe('GatheringClient && GatheringServer', () => {
     })
   })
 
-  it('GatheringClient.request() sends an OBJECT, RPCServer.consume() sends back a response' +
+  it('GatheringClient.request() sends an OBJECT, GatheringServer.consume() sends back a response' +
     'with a 100MB random generated buffer and GatheringClient receives it', (done) => {
     const objectMessage = { foo: 'bar', bar: 'foo' }
 

--- a/test/Gathering.test.js
+++ b/test/Gathering.test.js
@@ -12,7 +12,7 @@ describe('GatheringClient && GatheringServer', () => {
   queueManager.setLogger(logger)
 
   const gatheringClient = queueManager.getGatheringClient(gatheringName, { queueMaxSize: 100, timeoutMs })
-  const gatheringServer1 = queueManager.getGatheringServer(gatheringName, { timeoutMs })
+  const gatheringServer1 = queueManager.getGatheringServer(gatheringName, { prefetchCount: 1, timeoutMs })
 
   before(() => {
     return queueManager.connect()

--- a/test/Gathering.test.js
+++ b/test/Gathering.test.js
@@ -12,15 +12,14 @@ describe('GatheringClient && GatheringServer', () => {
   queueManager.setLogger(logger)
 
   const gatheringClient = queueManager.getGatheringClient(gatheringName, { queueMaxSize: 100, timeoutMs })
-  const gatheringServer1 = queueManager.getGatheringServer(gatheringName, { /* queueMaxSize: 100, */ timeoutMs })
-  // const gatheringServer2 = queueManager.getGatheringServer(gatheringName, { /* queueMaxSize: 100, */ timeoutMs })
+  const gatheringServer1 = queueManager.getGatheringServer(gatheringName, { timeoutMs })
 
   before(() => {
     return queueManager.connect()
   })
 
   after(() => {
-    // logger.empty()
+    logger.empty()
   })
 
   it('GatheringClient.request() sends a STRING and GatheringServer.consume() receives it', (done) => {

--- a/test/GatheringAction.test.js
+++ b/test/GatheringAction.test.js
@@ -1,0 +1,69 @@
+const QueueManager = require('../src/QueueManager')
+const ConsoleInspector = require('./consoleInspector')
+const config = require('./config/LoadConfig')
+const chai = require('chai')
+const expect = chai.expect
+
+describe('GatheringClient && GatheringServer actions', () => {
+  const gatheringName = 'test-gathering-action'
+  const logger = new ConsoleInspector(console)
+  const timeoutMs = 1000
+
+  const queueManager = new QueueManager(config)
+  queueManager.setLogger(logger)
+
+  const gatheringClient = queueManager.getGatheringClient(gatheringName, { queueMaxSize: 100, timeoutMs })
+  const gatheringServer1 = queueManager.getGatheringServer(gatheringName, { prefetchCount: 1, timeoutMs })
+
+  before(() => {
+    return queueManager.connect()
+  })
+
+  after(() => {
+    logger.empty()
+  })
+
+  it('GatheringServer.registerAction() registers the action, GatheringClient.callAction() sends a STRING and the registered callback for the action receives it', (done) => {
+    const stringMessage = 'foobar'
+
+    gatheringServer1.registerAction('compareString', (msg) => {
+      if (msg === stringMessage) {
+        done()
+      } else {
+        done(new Error(`The compared String is not equal to the String that was sent ${msg}`))
+      }
+    })
+
+    gatheringClient.requestAction('compareString', stringMessage, 1000).catch((err) => {
+      done(err)
+    })
+  })
+
+  it('GatheringServer handles unserializeable content', (done) => {
+    gatheringServer1.registerAction('wrongtest1', () => {
+      done(new Error('GatheringServer Action should not be called'))
+    })
+
+    const obj = {}
+    obj.a = { b: obj }
+
+    gatheringClient.requestAction('wrongtest1', obj, 1000).then(() => {
+      done('GatheringServer successfully sent unsendable data')
+    }).catch((err) => {
+      expect(err).to.be.an.instanceof(Error)
+      done()
+    })
+  })
+
+  it('GatheringServer responds with not found when no action handler is registered', (done) => {
+    gatheringClient.requestAction('notfound', 'hello', 1000).then((response) => {
+      if (typeof response === 'undefined') {
+        done()
+      } else {
+        done(new Error('Response should have been undefined'))
+      }
+    }).catch((err) => {
+      done(err)
+    })
+  })
+})


### PR DESCRIPTION
Adds the ability to request response from multiple possible server sources.
Gathering is achieved by publishing the message to multiple consumers and keeping track of responses from all of them.
If every consumer replies with a `not_found` message, the gathering request is rejected.
If at least one of the consumers replies with a found (`ok`) message, the gathering request is resolved with that response.
Multiple servers may reply with an acceptable response, but only the first will be used, the other ones are rejected/swallowed.
Replies (both statuses and the actual response) are counted against the number of consumers on a status queue.
